### PR TITLE
fixes #25 | navigation bug with multiple choice questions

### DIFF
--- a/Creator/UI.cs
+++ b/Creator/UI.cs
@@ -663,9 +663,9 @@ namespace Creator
             txt_question_text.Clear();
             txt_explanation.Clear();
             pct_image.Image = null;
-            //
+            // Clear all the options
             pan_options.Controls.Clear();
-            //
+            // Remove test in the text boxes
             txt_code.Clear();
             txt_instruction.Clear();
             txt_title.Clear();

--- a/Simulator/Exam UI.cs
+++ b/Simulator/Exam UI.cs
@@ -272,7 +272,9 @@ namespace Simulator
 
         private object SelectedAnswer()
         {
+            // Get the current question
             Question currentQuestion = settings.Questions[currentQuestionIndex];
+            // Determine the question type and return an answer
             if (currentQuestion.IsMultipleChoice)
             {
                 var chks = pan_display.Controls.OfType<CheckBox>().Where(s => s.Checked);

--- a/Simulator/Exam UI.cs
+++ b/Simulator/Exam UI.cs
@@ -272,17 +272,31 @@ namespace Simulator
 
         private object SelectedAnswer()
         {
-            var rdb = pan_display.Controls.OfType<RadioButton>().FirstOrDefault(s => s.Checked);
-            if (rdb == null)
+            Question currentQuestion = settings.Questions[currentQuestionIndex];
+            if (currentQuestion.IsMultipleChoice)
             {
                 var chks = pan_display.Controls.OfType<CheckBox>().Where(s => s.Checked);
                 if (chks == null || chks.Count() == 0)
-                    return '\0';
+                {
+                    return new List<char>().ToArray();
+                }
                 else
+                {
                     return chks.Select(s => Convert.ToChar(s.Text.Substring(0, 1))).ToArray();
+                }
             }
             else
-                return Convert.ToChar(rdb.Text.Substring(0, 1));
+            {
+                var rdb = pan_display.Controls.OfType<RadioButton>().FirstOrDefault(s => s.Checked);
+                if (rdb == null)
+                {
+                    return '\0';
+                }
+                else
+                {
+                    return Convert.ToChar(rdb.Text.Substring(0, 1));
+                }
+            }
         }
 
         private void ShowAnswer(object sender, EventArgs e)


### PR DESCRIPTION
The bug was caused by the way the app determined which question was a multiple choice question. the previous system used an unreliable method that later caused cast exceptions if a user didn't select an option.