### PR TITLE
Solving location issues in Windows 10

### DIFF
--- a/src/apps/Simulator/GUI/AssessmentUi.Designer.cs
+++ b/src/apps/Simulator/GUI/AssessmentUi.Designer.cs
@@ -29,8 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources =
-                new System.ComponentModel.ComponentResourceManager(typeof(Simulator.GUI.AssessmentUi));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AssessmentUi));
             this.label1 = new System.Windows.Forms.Label();
             this.lbl_elapsed_time = new System.Windows.Forms.Label();
             this.btn_begin = new System.Windows.Forms.Button();
@@ -55,97 +54,108 @@
             this.dspExamProgress = new System.Windows.Forms.Label();
             this.lblExamProgress = new System.Windows.Forms.Label();
             this.pan_display.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize) (this.pct_image)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pct_image)).BeginInit();
             this.SuspendLayout();
-            this.label1.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(1728, 18);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(1037, 9);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(88, 25);
+            this.label1.Size = new System.Drawing.Size(54, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Time Left:";
             this.label1.Visible = false;
-            this.lbl_elapsed_time.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lbl_elapsed_time
+            // 
+            this.lbl_elapsed_time.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lbl_elapsed_time.AutoSize = true;
-            this.lbl_elapsed_time.Location = new System.Drawing.Point(1827, 18);
-            this.lbl_elapsed_time.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_elapsed_time.Location = new System.Drawing.Point(1096, 9);
+            this.lbl_elapsed_time.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_elapsed_time.Name = "lbl_elapsed_time";
-            this.lbl_elapsed_time.Size = new System.Drawing.Size(0, 25);
+            this.lbl_elapsed_time.Size = new System.Drawing.Size(0, 13);
             this.lbl_elapsed_time.TabIndex = 1;
             this.lbl_elapsed_time.Visible = false;
-            this.btn_begin.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_begin.Location = new System.Drawing.Point(22, 1291);
-            this.btn_begin.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_begin
+            // 
+            this.btn_begin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btn_begin.Location = new System.Drawing.Point(910, 532);
+            this.btn_begin.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_begin.Name = "btn_begin";
-            this.btn_begin.Size = new System.Drawing.Size(124, 44);
+            this.btn_begin.Size = new System.Drawing.Size(74, 23);
             this.btn_begin.TabIndex = 2;
             this.btn_begin.Text = "Begin";
             this.btn_begin.UseVisualStyleBackColor = true;
             this.btn_begin.Click += new System.EventHandler(this.Begin);
-            this.btn_previous.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Left)));
+            // 
+            // btn_previous
+            // 
+            this.btn_previous.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btn_previous.Enabled = false;
-            this.btn_previous.Location = new System.Drawing.Point(22, 1291);
-            this.btn_previous.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.btn_previous.Location = new System.Drawing.Point(32, 532);
+            this.btn_previous.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_previous.Name = "btn_previous";
-            this.btn_previous.Size = new System.Drawing.Size(124, 44);
+            this.btn_previous.Size = new System.Drawing.Size(74, 23);
             this.btn_previous.TabIndex = 3;
             this.btn_previous.Text = "Previous";
             this.btn_previous.UseVisualStyleBackColor = true;
             this.btn_previous.Visible = false;
             this.btn_previous.Click += new System.EventHandler(this.Previous);
-            this.btn_next.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Left)));
+            // 
+            // btn_next
+            // 
+            this.btn_next.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btn_next.Enabled = false;
-            this.btn_next.Location = new System.Drawing.Point(176, 1291);
-            this.btn_next.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.btn_next.Location = new System.Drawing.Point(110, 532);
+            this.btn_next.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_next.Name = "btn_next";
-            this.btn_next.Size = new System.Drawing.Size(124, 44);
+            this.btn_next.Size = new System.Drawing.Size(74, 23);
             this.btn_next.TabIndex = 4;
             this.btn_next.Text = "Next";
             this.btn_next.UseVisualStyleBackColor = true;
             this.btn_next.Visible = false;
             this.btn_next.Click += new System.EventHandler(this.Next);
-            this.btn_pause.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_pause.Location = new System.Drawing.Point(1661, 1291);
-            this.btn_pause.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_pause
+            // 
+            this.btn_pause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_pause.Location = new System.Drawing.Point(990, 532);
+            this.btn_pause.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_pause.Name = "btn_pause";
-            this.btn_pause.Size = new System.Drawing.Size(124, 44);
+            this.btn_pause.Size = new System.Drawing.Size(74, 23);
             this.btn_pause.TabIndex = 5;
             this.btn_pause.Text = "Pause";
             this.btn_pause.UseVisualStyleBackColor = true;
             this.btn_pause.Visible = false;
             this.btn_pause.Click += new System.EventHandler(this.PauseExam);
-            this.btn_end.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_end.Location = new System.Drawing.Point(1811, 1291);
-            this.btn_end.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_end
+            // 
+            this.btn_end.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_end.Location = new System.Drawing.Point(1068, 532);
+            this.btn_end.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_end.Name = "btn_end";
-            this.btn_end.Size = new System.Drawing.Size(124, 44);
+            this.btn_end.Size = new System.Drawing.Size(74, 23);
             this.btn_end.TabIndex = 6;
             this.btn_end.Text = "End";
             this.btn_end.UseVisualStyleBackColor = true;
             this.btn_end.Visible = false;
             this.btn_end.Click += new System.EventHandler(this.End);
-            this.pan_display.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top |
-                                                         System.Windows.Forms.AnchorStyles.Bottom) |
-                                                        System.Windows.Forms.AnchorStyles.Left) |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // pan_display
+            // 
+            this.pan_display.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pan_display.AutoScroll = true;
+            this.pan_display.AutoSize = true;
             this.pan_display.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.pan_display.Controls.Add(this.pct_image);
+            this.pan_display.Controls.Add(this.lbl_explanation);
             this.pan_display.Controls.Add(this.txt_question);
             this.pan_display.Controls.Add(this.lbl_question_number);
             this.pan_display.Controls.Add(this.label3);
@@ -154,182 +164,217 @@
             this.pan_display.Controls.Add(this.lbl_exam_code);
             this.pan_display.Controls.Add(this.lbl_exam_instructions);
             this.pan_display.Controls.Add(this.lbl_exam_title);
-            this.pan_display.Location = new System.Drawing.Point(50, 65);
-            this.pan_display.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.pan_display.Location = new System.Drawing.Point(30, 34);
+            this.pan_display.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pan_display.Name = "pan_display";
-            this.pan_display.Size = new System.Drawing.Size(1864, 1084);
+            this.pan_display.Size = new System.Drawing.Size(1112, 479);
             this.pan_display.TabIndex = 7;
-            this.pct_image.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.pct_image.Location = new System.Drawing.Point(124, 298);
-            this.pct_image.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // pct_image
+            // 
+            this.pct_image.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pct_image.BackColor = System.Drawing.SystemColors.Control;
+            this.pct_image.Location = new System.Drawing.Point(28, 112);
+            this.pct_image.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pct_image.Name = "pct_image";
-            this.pct_image.Size = new System.Drawing.Size(964, 496);
+            this.pct_image.Size = new System.Drawing.Size(440, 176);
             this.pct_image.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pct_image.TabIndex = 12;
             this.pct_image.TabStop = false;
             this.pct_image.Visible = false;
-            this.txt_question.Anchor =
-                ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top |
-                                                        System.Windows.Forms.AnchorStyles.Left) |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txt_question
+            // 
+            this.txt_question.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txt_question.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.txt_question.Location = new System.Drawing.Point(56, 148);
-            this.txt_question.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.txt_question.Location = new System.Drawing.Point(34, 77);
+            this.txt_question.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.txt_question.Multiline = true;
             this.txt_question.Name = "txt_question";
             this.txt_question.ReadOnly = true;
-            this.txt_question.Size = new System.Drawing.Size(1691, 139);
+            this.txt_question.Size = new System.Drawing.Size(967, 72);
             this.txt_question.TabIndex = 11;
             this.txt_question.Visible = false;
+            // 
+            // lbl_question_number
+            // 
             this.lbl_question_number.AutoSize = true;
-            this.lbl_question_number.Location = new System.Drawing.Point(147, 90);
-            this.lbl_question_number.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_question_number.Location = new System.Drawing.Point(88, 47);
+            this.lbl_question_number.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_question_number.Name = "lbl_question_number";
-            this.lbl_question_number.Size = new System.Drawing.Size(176, 25);
+            this.lbl_question_number.Size = new System.Drawing.Size(104, 13);
             this.lbl_question_number.TabIndex = 10;
             this.lbl_question_number.Text = "lbl_question_number";
             this.lbl_question_number.Visible = false;
+            // 
+            // label3
+            // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(50, 90);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(30, 47);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(88, 25);
+            this.label3.Size = new System.Drawing.Size(52, 13);
             this.label3.TabIndex = 9;
             this.label3.Text = "Question:";
             this.label3.Visible = false;
+            // 
+            // lbl_section_title
+            // 
             this.lbl_section_title.AutoSize = true;
-            this.lbl_section_title.Location = new System.Drawing.Point(137, 39);
-            this.lbl_section_title.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_section_title.Location = new System.Drawing.Point(82, 20);
+            this.lbl_section_title.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_section_title.Name = "lbl_section_title";
-            this.lbl_section_title.Size = new System.Drawing.Size(130, 25);
+            this.lbl_section_title.Size = new System.Drawing.Size(79, 13);
             this.lbl_section_title.TabIndex = 8;
             this.lbl_section_title.Text = "lbl_section_title";
             this.lbl_section_title.Visible = false;
+            // 
+            // label2
+            // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(50, 39);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(30, 20);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(74, 25);
+            this.label2.Size = new System.Drawing.Size(46, 13);
             this.label2.TabIndex = 7;
             this.label2.Text = "Section:";
             this.label2.Visible = false;
+            // 
+            // lbl_exam_code
+            // 
             this.lbl_exam_code.AutoSize = true;
-            this.lbl_exam_code.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F,
-                System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.lbl_exam_code.Location = new System.Drawing.Point(42, 104);
-            this.lbl_exam_code.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_exam_code.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_exam_code.Location = new System.Drawing.Point(25, 54);
+            this.lbl_exam_code.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_exam_code.Name = "lbl_exam_code";
-            this.lbl_exam_code.Size = new System.Drawing.Size(133, 20);
+            this.lbl_exam_code.Size = new System.Drawing.Size(105, 15);
             this.lbl_exam_code.TabIndex = 2;
             this.lbl_exam_code.Text = "lbl_exam_code";
+            // 
+            // lbl_exam_instructions
+            // 
             this.lbl_exam_instructions.AutoSize = true;
-            this.lbl_exam_instructions.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F,
-                System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.lbl_exam_instructions.Location = new System.Drawing.Point(42, 164);
-            this.lbl_exam_instructions.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_exam_instructions.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_exam_instructions.Location = new System.Drawing.Point(25, 85);
+            this.lbl_exam_instructions.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_exam_instructions.Name = "lbl_exam_instructions";
-            this.lbl_exam_instructions.Size = new System.Drawing.Size(53, 20);
+            this.lbl_exam_instructions.Size = new System.Drawing.Size(41, 15);
             this.lbl_exam_instructions.TabIndex = 1;
             this.lbl_exam_instructions.Text = "label4";
+            // 
+            // lbl_exam_title
+            // 
             this.lbl_exam_title.AutoSize = true;
-            this.lbl_exam_title.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.5F,
-                System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.lbl_exam_title.Location = new System.Drawing.Point(42, 39);
-            this.lbl_exam_title.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_exam_title.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.5F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_exam_title.Location = new System.Drawing.Point(25, 20);
+            this.lbl_exam_title.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_exam_title.Name = "lbl_exam_title";
-            this.lbl_exam_title.Size = new System.Drawing.Size(137, 24);
+            this.lbl_exam_title.Size = new System.Drawing.Size(103, 16);
             this.lbl_exam_title.TabIndex = 0;
             this.lbl_exam_title.Text = "lbl_exam_title";
+            // 
+            // timer
+            // 
             this.timer.Interval = 1000;
             this.timer.Tick += new System.EventHandler(this.TimerTick);
-            this.btn_show_answer.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_show_answer.Location = new System.Drawing.Point(1563, 8);
-            this.btn_show_answer.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_show_answer
+            // 
+            this.btn_show_answer.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_show_answer.Location = new System.Drawing.Point(938, 4);
+            this.btn_show_answer.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_show_answer.Name = "btn_show_answer";
-            this.btn_show_answer.Size = new System.Drawing.Size(144, 44);
+            this.btn_show_answer.Size = new System.Drawing.Size(86, 23);
             this.btn_show_answer.TabIndex = 8;
             this.btn_show_answer.Text = "Show Answer";
             this.btn_show_answer.UseVisualStyleBackColor = true;
             this.btn_show_answer.Visible = false;
             this.btn_show_answer.Click += new System.EventHandler(this.ShowAnswer);
-            this.lbl_explanation.Anchor =
-                ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Bottom |
-                                                        System.Windows.Forms.AnchorStyles.Left) |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lbl_explanation
+            // 
+            this.lbl_explanation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lbl_explanation.BackColor = System.Drawing.SystemColors.Control;
             this.lbl_explanation.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.lbl_explanation.Cursor = System.Windows.Forms.Cursors.Default;
-            this.lbl_explanation.Location = new System.Drawing.Point(87, 1175);
-            this.lbl_explanation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_explanation.Location = new System.Drawing.Point(28, 291);
+            this.lbl_explanation.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_explanation.Multiline = true;
             this.lbl_explanation.Name = "lbl_explanation";
             this.lbl_explanation.ReadOnly = true;
-            this.lbl_explanation.Size = new System.Drawing.Size(1794, 94);
+            this.lbl_explanation.Size = new System.Drawing.Size(1075, 49);
             this.lbl_explanation.TabIndex = 9;
             this.lbl_explanation.Text = "lbl_explanation";
             this.lbl_explanation.Visible = false;
-            this.btnHideAnswers.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btnHideAnswers.Location = new System.Drawing.Point(1563, 8);
-            this.btnHideAnswers.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btnHideAnswers
+            // 
+            this.btnHideAnswers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnHideAnswers.Location = new System.Drawing.Point(938, 4);
+            this.btnHideAnswers.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btnHideAnswers.Name = "btnHideAnswers";
-            this.btnHideAnswers.Size = new System.Drawing.Size(144, 44);
+            this.btnHideAnswers.Size = new System.Drawing.Size(86, 23);
             this.btnHideAnswers.TabIndex = 10;
             this.btnHideAnswers.Text = "Hide Answer";
             this.btnHideAnswers.UseVisualStyleBackColor = true;
             this.btnHideAnswers.Visible = false;
             this.btnHideAnswers.Click += new System.EventHandler(this.HideAnswer);
-            this.dspExamProgress.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // dspExamProgress
+            // 
+            this.dspExamProgress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.dspExamProgress.AutoSize = true;
-            this.dspExamProgress.Location = new System.Drawing.Point(1358, 18);
-            this.dspExamProgress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.dspExamProgress.Location = new System.Drawing.Point(815, 9);
+            this.dspExamProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.dspExamProgress.Name = "dspExamProgress";
-            this.dspExamProgress.Size = new System.Drawing.Size(0, 25);
+            this.dspExamProgress.Size = new System.Drawing.Size(0, 13);
             this.dspExamProgress.TabIndex = 12;
             this.dspExamProgress.Visible = false;
-            this.lblExamProgress.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lblExamProgress
+            // 
+            this.lblExamProgress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblExamProgress.AutoSize = true;
-            this.lblExamProgress.Location = new System.Drawing.Point(1213, 18);
-            this.lblExamProgress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblExamProgress.Location = new System.Drawing.Point(728, 9);
+            this.lblExamProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblExamProgress.Name = "lblExamProgress";
-            this.lblExamProgress.Size = new System.Drawing.Size(137, 25);
+            this.lblExamProgress.Size = new System.Drawing.Size(83, 13);
             this.lblExamProgress.TabIndex = 11;
             this.lblExamProgress.Text = " Exam Progress:";
             this.lblExamProgress.Visible = false;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            // 
+            // AssessmentUi
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1962, 1358);
+            this.ClientSize = new System.Drawing.Size(1154, 564);
             this.Controls.Add(this.btnHideAnswers);
-            this.Controls.Add(this.lbl_explanation);
             this.Controls.Add(this.btn_show_answer);
             this.Controls.Add(this.pan_display);
-            this.Controls.Add(this.btn_end);
             this.Controls.Add(this.btn_pause);
-            this.Controls.Add(this.btn_next);
-            this.Controls.Add(this.btn_previous);
+            this.Controls.Add(this.btn_end);
             this.Controls.Add(this.btn_begin);
+            this.Controls.Add(this.btn_previous);
+            this.Controls.Add(this.btn_next);
             this.Controls.Add(this.lbl_elapsed_time);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lblExamProgress);
             this.Controls.Add(this.dspExamProgress);
-            this.Icon = ((System.Drawing.Icon) (resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.Name = "AssessmentUi";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Open Exam Simulator";
             this.Load += new System.EventHandler(this.Start);
             this.pan_display.ResumeLayout(false);
             this.pan_display.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize) (this.pct_image)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pct_image)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
 #endregion

--- a/src/apps/Simulator/GUI/AssessmentUi.cs
+++ b/src/apps/Simulator/GUI/AssessmentUi.cs
@@ -254,7 +254,7 @@ namespace Simulator.GUI
                         AutoSize = true,
                         Text = $"{options[i].Alphabet}. - {options[i].Text}",
                         Name = "chk" + options[i].Alphabet,
-                        Location = new Point(51, 464 + (i * 22))
+                        Location = new Point(51, 364 + (i * 22))
                     };
                     if (_userAnswers[_currentQuestionIndex] != null &&
                         ((char[]) _userAnswers[_currentQuestionIndex]).Contains(options[i].Alphabet))
@@ -268,7 +268,7 @@ namespace Simulator.GUI
                         AutoSize = true,
                         Text = options[i].Alphabet + ". - " + options[i].Text,
                         Name = "rdb" + options[i].Alphabet,
-                        Location = new Point(51, 464 + (i * 22))
+                        Location = new Point(51, 364 + (i * 22))
                     };
                     if (_userAnswers[_currentQuestionIndex] != null &&
                         (char) _userAnswers[_currentQuestionIndex] == options[i].Alphabet)


### PR DESCRIPTION
This commit solves issues related to location in Windows 10 that made not visible exam controls to be able to move to next question or previous one.

Image before

![image](https://user-images.githubusercontent.com/947041/59144811-1e8edb80-89dc-11e9-85d1-74e52e2ece9d.png)

Image now:

![Simulator_2019-06-08_10-48-43](https://user-images.githubusercontent.com/947041/59144807-0454fd80-89dc-11e9-97f5-f6494f81c050.png)
