### PR TITLE
Mark questions for review

### DIFF
--- a/src/apps/Creator/GUI/AboutUi.Designer.cs
+++ b/src/apps/Creator/GUI/AboutUi.Designer.cs
@@ -47,7 +47,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(156, 15);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Open Exam Creator 3.1.2";
+            this.label1.Text = "Open Exam Creator 4.0.0";
             // 
             // label2
             // 

--- a/src/apps/Creator/GUI/HomeUi.Designer.cs
+++ b/src/apps/Creator/GUI/HomeUi.Designer.cs
@@ -541,7 +541,7 @@
             this.lbl_version.Name = "lbl_version";
             this.lbl_version.Size = new System.Drawing.Size(31, 20);
             this.lbl_version.TabIndex = 9;
-            this.lbl_version.Text = "3.1";
+            this.lbl_version.Text = "4.0";
             // 
             // txt_code
             // 

--- a/src/apps/Creator/GUI/HomeUi.cs
+++ b/src/apps/Creator/GUI/HomeUi.cs
@@ -131,7 +131,7 @@ namespace Creator.GUI
                 txt_code.Text = _exam.Properties.Code;
                 txt_instruction.Text = _exam.Properties.Instructions;
                 txt_title.Text = _exam.Properties.Title;
-                num_passmark.Value = (decimal) _exam.Properties.Passmark;
+                num_passmark.Value = (decimal)_exam.Properties.Passmark;
                 num_time_limit.Value = _exam.Properties.TimeLimit;
                 _undoRedo = new UndoRedo();
 
@@ -163,7 +163,7 @@ namespace Creator.GUI
                 if (trv_view_exam.SelectedNode != null)
                     if (trv_view_exam.SelectedNode.GetType() == typeof(QuestionNode))
                         CommitQuestion();
-                var examNode = (ExamNode) trv_view_exam.Nodes[0];
+                var examNode = (ExamNode)trv_view_exam.Nodes[0];
                 _exam.Properties = examNode.Properties;
                 _exam.Sections.Clear();
                 foreach (SectionNode sectionNode in examNode.Nodes)
@@ -207,7 +207,7 @@ namespace Creator.GUI
 
         private void CommitQuestion()
         {
-            var question = ((QuestionNode) trv_view_exam.SelectedNode).Question;
+            var question = ((QuestionNode)trv_view_exam.SelectedNode).Question;
             question.IsMultipleChoice = chkMulipleChoice.Checked;
             if (question.IsMultipleChoice)
             {
@@ -221,7 +221,7 @@ namespace Creator.GUI
             }
 
             question.Explanation = txt_explanation.Text;
-            question.Image = (Bitmap) pct_image.Image;
+            question.Image = (Bitmap)pct_image.Image;
             question.No = trv_view_exam.SelectedNode.Index + 1;
             question.Options.Clear();
             if (question.IsMultipleChoice)
@@ -358,7 +358,7 @@ namespace Creator.GUI
                         .FirstOrDefault(s => s.Title == undoObject.SectionTitle);
                     if (sectionNode_ != null)
                     {
-                        var questionNode = (QuestionNode) sectionNode_.Nodes[undoObject.Question.No - 1];
+                        var questionNode = (QuestionNode)sectionNode_.Nodes[undoObject.Question.No - 1];
                         questionNode.Question = undoObject.Question;
                         txt_explanation.Text = undoObject.Question.Explanation;
                         txt_question_text.Text = undoObject.Question.Text;
@@ -481,7 +481,7 @@ namespace Creator.GUI
                         .FirstOrDefault(s => s.Title == redoObject.SectionTitle);
                     if (sectionNode_ != null)
                     {
-                        var questionNode = (QuestionNode) sectionNode_.Nodes[redoObject.Question.No - 1];
+                        var questionNode = (QuestionNode)sectionNode_.Nodes[redoObject.Question.No - 1];
                         questionNode.Question = redoObject.Question;
                         txt_explanation.Text = redoObject.Question.Explanation;
                         txt_question_text.Text = redoObject.Question.Text;
@@ -558,10 +558,11 @@ namespace Creator.GUI
         {
             // add question to section node
             var nodeToBeAddedTo = trv_view_exam.SelectedNode.GetType() == typeof(SectionNode)
-                ? (SectionNode) trv_view_exam.SelectedNode
-                : (SectionNode) trv_view_exam.SelectedNode.Parent;
+                ? (SectionNode)trv_view_exam.SelectedNode
+                : (SectionNode)trv_view_exam.SelectedNode.Parent;
             var question = new Question
             {
+                Id = Guid.NewGuid(),
                 No = nodeToBeAddedTo.Nodes.Count + 1
             };
             var questionNode = new QuestionNode(question)
@@ -676,7 +677,7 @@ namespace Creator.GUI
                 }
 
                 pan_display_questions.Enabled = true;
-                var question = ((QuestionNode) trv_view_exam.SelectedNode).Question;
+                var question = ((QuestionNode)trv_view_exam.SelectedNode).Question;
                 txt_explanation.Text = question.Explanation;
                 txt_question_text.Text = question.Text;
                 lbl_section_question.Text =
@@ -745,10 +746,10 @@ namespace Creator.GUI
             txt_question_text.Clear();
             txt_explanation.Clear();
             pct_image.Image = null;
-            
+
             // Clear all the options
             pan_options.Controls.Clear();
-            
+
             // Remove test in the text boxes
             txt_code.Clear();
             txt_instruction.Clear();
@@ -761,14 +762,14 @@ namespace Creator.GUI
             {
                 Code = txt_code.Text,
                 Instructions = txt_instruction.Text,
-                Passmark = (int) num_passmark.Value,
-                TimeLimit = (int) num_time_limit.Value,
+                Passmark = (int)num_passmark.Value,
+                TimeLimit = (int)num_time_limit.Value,
                 Title = txt_title.Text,
-                Version = (int) float.Parse(lbl_version.Text)
+                Version = (int)float.Parse(lbl_version.Text)
             };
             if (trv_view_exam.Nodes.Count > 0)
             {
-                var examNode = (ExamNode) trv_view_exam.Nodes[0];
+                var examNode = (ExamNode)trv_view_exam.Nodes[0];
                 examNode.Properties = properties;
             }
             else
@@ -865,7 +866,7 @@ namespace Creator.GUI
             ClearControls();
             trv_view_exam.Nodes.Clear();
             DisableAllControls();
-            
+
             if (splitContainer2.Panel2.Contains(pan_display_questions))
             {
                 splitContainer2.Panel2.Controls.Remove(pan_display_questions);
@@ -880,7 +881,7 @@ namespace Creator.GUI
             _exam = null;
             _undoRedo = null;
             IsDirty = false;
-            
+
             LoadExamHistory();
         }
 
@@ -933,8 +934,8 @@ namespace Creator.GUI
                         var ctrl = new OptionsControl
                         {
                             Name = "option" + (pan_options.Controls.Count - 1),
-                            Letter = (char) (Convert.ToInt32(
-                                                 ((OptionsControl) pan_options.Controls[pan_options.Controls.Count - 1])
+                            Letter = (char)(Convert.ToInt32(
+                                                 ((OptionsControl)pan_options.Controls[pan_options.Controls.Count - 1])
                                                  .Letter) + 1),
                             Location = new Point(2, 2 + pan_options.Controls.Count * 36)
                         };
@@ -958,8 +959,8 @@ namespace Creator.GUI
                         var ctrl = new OptionControl
                         {
                             Name = "option" + (pan_options.Controls.Count - 1),
-                            Letter = (char) (Convert.ToInt32(
-                                                 ((OptionControl) pan_options.Controls[pan_options.Controls.Count - 1])
+                            Letter = (char)(Convert.ToInt32(
+                                                 ((OptionControl)pan_options.Controls[pan_options.Controls.Count - 1])
                                                  .Letter) + 1),
                             Location = new Point(2, 2 + pan_options.Controls.Count * 36)
                         };
@@ -1125,9 +1126,9 @@ namespace Creator.GUI
 
         void ExamLinkClick(object sender, EventArgs e)
         {
-            if (File.Exists(((LinkLabel) sender).Text))
+            if (File.Exists(((LinkLabel)sender).Text))
             {
-                _currentExamFile = ((LinkLabel) sender).Text;
+                _currentExamFile = ((LinkLabel)sender).Text;
                 Open();
             }
             else
@@ -1137,10 +1138,10 @@ namespace Creator.GUI
 
                 // remove the setting from storage
                 var appSettingService = AppSettingsService.Instance;
-                appSettingService.Remove(((LinkLabel) sender).Text, AppSettingsType.Creator);
+                appSettingService.Remove(((LinkLabel)sender).Text, AppSettingsType.Creator);
 
                 // remove the link
-                grp_exam_history.Controls.Remove((Control) sender);
+                grp_exam_history.Controls.Remove((Control)sender);
             }
         }
 
@@ -1156,8 +1157,8 @@ namespace Creator.GUI
             var obj = new ChangeRepresentationObject
             {
                 Action = ActionType.Delete,
-                Question = ((QuestionNode) trv_view_exam.SelectedNode).Question,
-                SectionTitle = ((SectionNode) sectionNode).Title
+                Question = ((QuestionNode)trv_view_exam.SelectedNode).Question,
+                SectionTitle = ((SectionNode)sectionNode).Title
             };
             _undoRedo.InsertObjectforUndoRedo(obj);
 
@@ -1176,14 +1177,14 @@ namespace Creator.GUI
 
         private void EditSection(object sender, EventArgs e)
         {
-            var sectionNode = (SectionNode) trv_view_exam.SelectedNode;
-            
+            var sectionNode = (SectionNode)trv_view_exam.SelectedNode;
+
             var editSection = new EditSection(sectionNode.Title);
             editSection.ShowDialog();
-            
+
             sectionNode.Title = editSection.Title;
             sectionNode.Text = editSection.Title;
-            
+
             IsDirty = true;
         }
 
@@ -1195,12 +1196,12 @@ namespace Creator.GUI
         private void QuestionChanged(object sender, EventArgs e)
         {
             IsDirty = true;
-            
+
             var obj = new ChangeRepresentationObject
             {
                 Action = ActionType.Modify
             };
-            
+
             var question = new Question
             {
                 IsMultipleChoice = chkMulipleChoice.Checked
@@ -1217,7 +1218,7 @@ namespace Creator.GUI
             }
 
             question.Explanation = txt_explanation.Text;
-            question.Image = (Bitmap) pct_image.Image;
+            question.Image = (Bitmap)pct_image.Image;
             question.No = trv_view_exam.SelectedNode.Index + 1;
             question.Options.Clear();
             if (question.IsMultipleChoice)
@@ -1249,7 +1250,7 @@ namespace Creator.GUI
 
             question.Text = txt_question_text.Text;
             obj.Question = question;
-            obj.SectionTitle = ((SectionNode) trv_view_exam.SelectedNode.Parent).Title;
+            obj.SectionTitle = ((SectionNode)trv_view_exam.SelectedNode.Parent).Title;
             _undoRedo.InsertObjectforUndoRedo(obj);
         }
 

--- a/src/apps/Creator/Properties/AssemblyInfo.cs
+++ b/src/apps/Creator/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0.0")]
-[assembly: AssemblyFileVersion("3.2.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/src/apps/Simulator/GUI/AboutUi.Designer.cs
+++ b/src/apps/Simulator/GUI/AboutUi.Designer.cs
@@ -46,7 +46,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(171, 15);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Open Exam Simulator 3.1.2";
+            this.label1.Text = "Open Exam Simulator 4.0.0";
             // 
             // label2
             // 

--- a/src/apps/Simulator/GUI/AssessmentUi.Designer.cs
+++ b/src/apps/Simulator/GUI/AssessmentUi.Designer.cs
@@ -29,8 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources =
-                new System.ComponentModel.ComponentResourceManager(typeof(Simulator.GUI.AssessmentUi));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AssessmentUi));
             this.label1 = new System.Windows.Forms.Label();
             this.lbl_elapsed_time = new System.Windows.Forms.Label();
             this.btn_begin = new System.Windows.Forms.Button();
@@ -55,97 +54,106 @@
             this.dspExamProgress = new System.Windows.Forms.Label();
             this.lblExamProgress = new System.Windows.Forms.Label();
             this.pan_display.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize) (this.pct_image)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pct_image)).BeginInit();
             this.SuspendLayout();
-            this.label1.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(1728, 18);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(1044, 9);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(88, 25);
+            this.label1.Size = new System.Drawing.Size(54, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Time Left:";
             this.label1.Visible = false;
-            this.lbl_elapsed_time.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lbl_elapsed_time
+            // 
+            this.lbl_elapsed_time.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lbl_elapsed_time.AutoSize = true;
-            this.lbl_elapsed_time.Location = new System.Drawing.Point(1827, 18);
-            this.lbl_elapsed_time.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_elapsed_time.Location = new System.Drawing.Point(1103, 9);
+            this.lbl_elapsed_time.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_elapsed_time.Name = "lbl_elapsed_time";
-            this.lbl_elapsed_time.Size = new System.Drawing.Size(0, 25);
+            this.lbl_elapsed_time.Size = new System.Drawing.Size(0, 13);
             this.lbl_elapsed_time.TabIndex = 1;
             this.lbl_elapsed_time.Visible = false;
-            this.btn_begin.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_begin.Location = new System.Drawing.Point(22, 1291);
-            this.btn_begin.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_begin
+            // 
+            this.btn_begin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btn_begin.Location = new System.Drawing.Point(186, 598);
+            this.btn_begin.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_begin.Name = "btn_begin";
-            this.btn_begin.Size = new System.Drawing.Size(124, 44);
+            this.btn_begin.Size = new System.Drawing.Size(74, 23);
             this.btn_begin.TabIndex = 2;
             this.btn_begin.Text = "Begin";
             this.btn_begin.UseVisualStyleBackColor = true;
             this.btn_begin.Click += new System.EventHandler(this.Begin);
-            this.btn_previous.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Left)));
+            // 
+            // btn_previous
+            // 
+            this.btn_previous.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btn_previous.Enabled = false;
-            this.btn_previous.Location = new System.Drawing.Point(22, 1291);
-            this.btn_previous.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.btn_previous.Location = new System.Drawing.Point(30, 598);
+            this.btn_previous.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_previous.Name = "btn_previous";
-            this.btn_previous.Size = new System.Drawing.Size(124, 44);
+            this.btn_previous.Size = new System.Drawing.Size(74, 23);
             this.btn_previous.TabIndex = 3;
             this.btn_previous.Text = "Previous";
             this.btn_previous.UseVisualStyleBackColor = true;
             this.btn_previous.Visible = false;
             this.btn_previous.Click += new System.EventHandler(this.Previous);
-            this.btn_next.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Left)));
+            // 
+            // btn_next
+            // 
+            this.btn_next.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btn_next.Enabled = false;
-            this.btn_next.Location = new System.Drawing.Point(176, 1291);
-            this.btn_next.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.btn_next.Location = new System.Drawing.Point(108, 598);
+            this.btn_next.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_next.Name = "btn_next";
-            this.btn_next.Size = new System.Drawing.Size(124, 44);
+            this.btn_next.Size = new System.Drawing.Size(74, 23);
             this.btn_next.TabIndex = 4;
             this.btn_next.Text = "Next";
             this.btn_next.UseVisualStyleBackColor = true;
             this.btn_next.Visible = false;
             this.btn_next.Click += new System.EventHandler(this.Next);
-            this.btn_pause.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_pause.Location = new System.Drawing.Point(1661, 1291);
-            this.btn_pause.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_pause
+            // 
+            this.btn_pause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_pause.Location = new System.Drawing.Point(1004, 598);
+            this.btn_pause.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_pause.Name = "btn_pause";
-            this.btn_pause.Size = new System.Drawing.Size(124, 44);
+            this.btn_pause.Size = new System.Drawing.Size(74, 23);
             this.btn_pause.TabIndex = 5;
             this.btn_pause.Text = "Pause";
             this.btn_pause.UseVisualStyleBackColor = true;
             this.btn_pause.Visible = false;
             this.btn_pause.Click += new System.EventHandler(this.PauseExam);
-            this.btn_end.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_end.Location = new System.Drawing.Point(1811, 1291);
-            this.btn_end.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_end
+            // 
+            this.btn_end.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_end.Location = new System.Drawing.Point(1082, 598);
+            this.btn_end.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_end.Name = "btn_end";
-            this.btn_end.Size = new System.Drawing.Size(124, 44);
+            this.btn_end.Size = new System.Drawing.Size(74, 23);
             this.btn_end.TabIndex = 6;
             this.btn_end.Text = "End";
             this.btn_end.UseVisualStyleBackColor = true;
             this.btn_end.Visible = false;
             this.btn_end.Click += new System.EventHandler(this.End);
-            this.pan_display.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top |
-                                                         System.Windows.Forms.AnchorStyles.Bottom) |
-                                                        System.Windows.Forms.AnchorStyles.Left) |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // pan_display
+            // 
+            this.pan_display.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.pan_display.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.pan_display.Controls.Add(this.pct_image);
+            this.pan_display.Controls.Add(this.lbl_explanation);
             this.pan_display.Controls.Add(this.txt_question);
             this.pan_display.Controls.Add(this.lbl_question_number);
             this.pan_display.Controls.Add(this.label3);
@@ -154,160 +162,192 @@
             this.pan_display.Controls.Add(this.lbl_exam_code);
             this.pan_display.Controls.Add(this.lbl_exam_instructions);
             this.pan_display.Controls.Add(this.lbl_exam_title);
-            this.pan_display.Location = new System.Drawing.Point(50, 65);
-            this.pan_display.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.pan_display.Location = new System.Drawing.Point(30, 34);
+            this.pan_display.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pan_display.Name = "pan_display";
-            this.pan_display.Size = new System.Drawing.Size(1864, 1084);
+            this.pan_display.Size = new System.Drawing.Size(1126, 558);
             this.pan_display.TabIndex = 7;
+            // 
+            // pct_image
+            // 
             this.pct_image.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.pct_image.Location = new System.Drawing.Point(124, 298);
-            this.pct_image.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.pct_image.Location = new System.Drawing.Point(77, 117);
+            this.pct_image.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pct_image.Name = "pct_image";
-            this.pct_image.Size = new System.Drawing.Size(964, 496);
+            this.pct_image.Size = new System.Drawing.Size(337, 144);
             this.pct_image.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pct_image.TabIndex = 12;
             this.pct_image.TabStop = false;
             this.pct_image.Visible = false;
-            this.txt_question.Anchor =
-                ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top |
-                                                        System.Windows.Forms.AnchorStyles.Left) |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txt_question
+            // 
+            this.txt_question.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txt_question.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.txt_question.Location = new System.Drawing.Point(56, 148);
-            this.txt_question.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.txt_question.Location = new System.Drawing.Point(34, 77);
+            this.txt_question.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.txt_question.Multiline = true;
             this.txt_question.Name = "txt_question";
             this.txt_question.ReadOnly = true;
-            this.txt_question.Size = new System.Drawing.Size(1691, 139);
+            this.txt_question.Size = new System.Drawing.Size(1022, 72);
             this.txt_question.TabIndex = 11;
             this.txt_question.Visible = false;
+            // 
+            // lbl_question_number
+            // 
             this.lbl_question_number.AutoSize = true;
-            this.lbl_question_number.Location = new System.Drawing.Point(147, 90);
-            this.lbl_question_number.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_question_number.Location = new System.Drawing.Point(88, 47);
+            this.lbl_question_number.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_question_number.Name = "lbl_question_number";
-            this.lbl_question_number.Size = new System.Drawing.Size(176, 25);
+            this.lbl_question_number.Size = new System.Drawing.Size(104, 13);
             this.lbl_question_number.TabIndex = 10;
             this.lbl_question_number.Text = "lbl_question_number";
             this.lbl_question_number.Visible = false;
+            // 
+            // label3
+            // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(50, 90);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(30, 47);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(88, 25);
+            this.label3.Size = new System.Drawing.Size(52, 13);
             this.label3.TabIndex = 9;
             this.label3.Text = "Question:";
             this.label3.Visible = false;
+            // 
+            // lbl_section_title
+            // 
             this.lbl_section_title.AutoSize = true;
-            this.lbl_section_title.Location = new System.Drawing.Point(137, 39);
-            this.lbl_section_title.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_section_title.Location = new System.Drawing.Point(82, 20);
+            this.lbl_section_title.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_section_title.Name = "lbl_section_title";
-            this.lbl_section_title.Size = new System.Drawing.Size(130, 25);
+            this.lbl_section_title.Size = new System.Drawing.Size(79, 13);
             this.lbl_section_title.TabIndex = 8;
             this.lbl_section_title.Text = "lbl_section_title";
             this.lbl_section_title.Visible = false;
+            // 
+            // label2
+            // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(50, 39);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(30, 20);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(74, 25);
+            this.label2.Size = new System.Drawing.Size(46, 13);
             this.label2.TabIndex = 7;
             this.label2.Text = "Section:";
             this.label2.Visible = false;
+            // 
+            // lbl_exam_code
+            // 
             this.lbl_exam_code.AutoSize = true;
-            this.lbl_exam_code.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F,
-                System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.lbl_exam_code.Location = new System.Drawing.Point(42, 104);
-            this.lbl_exam_code.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_exam_code.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_exam_code.Location = new System.Drawing.Point(25, 54);
+            this.lbl_exam_code.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_exam_code.Name = "lbl_exam_code";
-            this.lbl_exam_code.Size = new System.Drawing.Size(133, 20);
+            this.lbl_exam_code.Size = new System.Drawing.Size(105, 15);
             this.lbl_exam_code.TabIndex = 2;
             this.lbl_exam_code.Text = "lbl_exam_code";
+            // 
+            // lbl_exam_instructions
+            // 
             this.lbl_exam_instructions.AutoSize = true;
-            this.lbl_exam_instructions.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F,
-                System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.lbl_exam_instructions.Location = new System.Drawing.Point(42, 164);
-            this.lbl_exam_instructions.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_exam_instructions.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_exam_instructions.Location = new System.Drawing.Point(25, 85);
+            this.lbl_exam_instructions.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_exam_instructions.Name = "lbl_exam_instructions";
-            this.lbl_exam_instructions.Size = new System.Drawing.Size(53, 20);
+            this.lbl_exam_instructions.Size = new System.Drawing.Size(41, 15);
             this.lbl_exam_instructions.TabIndex = 1;
             this.lbl_exam_instructions.Text = "label4";
+            // 
+            // lbl_exam_title
+            // 
             this.lbl_exam_title.AutoSize = true;
-            this.lbl_exam_title.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.5F,
-                System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.lbl_exam_title.Location = new System.Drawing.Point(42, 39);
-            this.lbl_exam_title.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_exam_title.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.5F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_exam_title.Location = new System.Drawing.Point(25, 20);
+            this.lbl_exam_title.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_exam_title.Name = "lbl_exam_title";
-            this.lbl_exam_title.Size = new System.Drawing.Size(137, 24);
+            this.lbl_exam_title.Size = new System.Drawing.Size(103, 16);
             this.lbl_exam_title.TabIndex = 0;
             this.lbl_exam_title.Text = "lbl_exam_title";
+            // 
+            // timer
+            // 
             this.timer.Interval = 1000;
             this.timer.Tick += new System.EventHandler(this.TimerTick);
-            this.btn_show_answer.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_show_answer.Location = new System.Drawing.Point(1563, 8);
-            this.btn_show_answer.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btn_show_answer
+            // 
+            this.btn_show_answer.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_show_answer.Location = new System.Drawing.Point(945, 4);
+            this.btn_show_answer.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_show_answer.Name = "btn_show_answer";
-            this.btn_show_answer.Size = new System.Drawing.Size(144, 44);
+            this.btn_show_answer.Size = new System.Drawing.Size(86, 23);
             this.btn_show_answer.TabIndex = 8;
             this.btn_show_answer.Text = "Show Answer";
             this.btn_show_answer.UseVisualStyleBackColor = true;
             this.btn_show_answer.Visible = false;
             this.btn_show_answer.Click += new System.EventHandler(this.ShowAnswer);
-            this.lbl_explanation.Anchor =
-                ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Bottom |
-                                                        System.Windows.Forms.AnchorStyles.Left) |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lbl_explanation
+            // 
+            this.lbl_explanation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lbl_explanation.BackColor = System.Drawing.SystemColors.Control;
             this.lbl_explanation.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.lbl_explanation.Cursor = System.Windows.Forms.Cursors.Default;
-            this.lbl_explanation.Location = new System.Drawing.Point(87, 1175);
-            this.lbl_explanation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lbl_explanation.Location = new System.Drawing.Point(28, 435);
+            this.lbl_explanation.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_explanation.Multiline = true;
             this.lbl_explanation.Name = "lbl_explanation";
             this.lbl_explanation.ReadOnly = true;
-            this.lbl_explanation.Size = new System.Drawing.Size(1794, 94);
+            this.lbl_explanation.Size = new System.Drawing.Size(1071, 109);
             this.lbl_explanation.TabIndex = 9;
             this.lbl_explanation.Text = "lbl_explanation";
             this.lbl_explanation.Visible = false;
-            this.btnHideAnswers.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.btnHideAnswers.Location = new System.Drawing.Point(1563, 8);
-            this.btnHideAnswers.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            // 
+            // btnHideAnswers
+            // 
+            this.btnHideAnswers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnHideAnswers.Location = new System.Drawing.Point(945, 4);
+            this.btnHideAnswers.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btnHideAnswers.Name = "btnHideAnswers";
-            this.btnHideAnswers.Size = new System.Drawing.Size(144, 44);
+            this.btnHideAnswers.Size = new System.Drawing.Size(86, 23);
             this.btnHideAnswers.TabIndex = 10;
             this.btnHideAnswers.Text = "Hide Answer";
             this.btnHideAnswers.UseVisualStyleBackColor = true;
             this.btnHideAnswers.Visible = false;
             this.btnHideAnswers.Click += new System.EventHandler(this.HideAnswer);
-            this.dspExamProgress.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // dspExamProgress
+            // 
+            this.dspExamProgress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.dspExamProgress.AutoSize = true;
-            this.dspExamProgress.Location = new System.Drawing.Point(1358, 18);
-            this.dspExamProgress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.dspExamProgress.Location = new System.Drawing.Point(822, 9);
+            this.dspExamProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.dspExamProgress.Name = "dspExamProgress";
-            this.dspExamProgress.Size = new System.Drawing.Size(0, 25);
+            this.dspExamProgress.Size = new System.Drawing.Size(0, 13);
             this.dspExamProgress.TabIndex = 12;
             this.dspExamProgress.Visible = false;
-            this.lblExamProgress.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lblExamProgress
+            // 
+            this.lblExamProgress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblExamProgress.AutoSize = true;
-            this.lblExamProgress.Location = new System.Drawing.Point(1213, 18);
-            this.lblExamProgress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblExamProgress.Location = new System.Drawing.Point(735, 9);
+            this.lblExamProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblExamProgress.Name = "lblExamProgress";
-            this.lblExamProgress.Size = new System.Drawing.Size(137, 25);
+            this.lblExamProgress.Size = new System.Drawing.Size(83, 13);
             this.lblExamProgress.TabIndex = 11;
             this.lblExamProgress.Text = " Exam Progress:";
             this.lblExamProgress.Visible = false;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            // 
+            // AssessmentUi
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1962, 1358);
+            this.ClientSize = new System.Drawing.Size(1184, 633);
             this.Controls.Add(this.btnHideAnswers);
-            this.Controls.Add(this.lbl_explanation);
             this.Controls.Add(this.btn_show_answer);
             this.Controls.Add(this.pan_display);
             this.Controls.Add(this.btn_end);
@@ -319,17 +359,18 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lblExamProgress);
             this.Controls.Add(this.dspExamProgress);
-            this.Icon = ((System.Drawing.Icon) (resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.Name = "AssessmentUi";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Open Exam Simulator";
             this.Load += new System.EventHandler(this.Start);
             this.pan_display.ResumeLayout(false);
             this.pan_display.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize) (this.pct_image)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pct_image)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
 #endregion

--- a/src/apps/Simulator/GUI/AssessmentUi.Designer.cs
+++ b/src/apps/Simulator/GUI/AssessmentUi.Designer.cs
@@ -38,7 +38,9 @@
             this.btn_pause = new System.Windows.Forms.Button();
             this.btn_end = new System.Windows.Forms.Button();
             this.pan_display = new System.Windows.Forms.Panel();
+            this.chkQuestionReview = new System.Windows.Forms.CheckBox();
             this.pct_image = new System.Windows.Forms.PictureBox();
+            this.lbl_explanation = new System.Windows.Forms.TextBox();
             this.txt_question = new System.Windows.Forms.TextBox();
             this.lbl_question_number = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
@@ -49,12 +51,13 @@
             this.lbl_exam_title = new System.Windows.Forms.Label();
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.btn_show_answer = new System.Windows.Forms.Button();
-            this.lbl_explanation = new System.Windows.Forms.TextBox();
             this.btnHideAnswers = new System.Windows.Forms.Button();
             this.dspExamProgress = new System.Windows.Forms.Label();
             this.lblExamProgress = new System.Windows.Forms.Label();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.pan_display.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pct_image)).BeginInit();
+            this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
@@ -152,6 +155,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.pan_display.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pan_display.Controls.Add(this.panel1);
             this.pan_display.Controls.Add(this.pct_image);
             this.pan_display.Controls.Add(this.lbl_explanation);
             this.pan_display.Controls.Add(this.txt_question);
@@ -168,6 +172,17 @@
             this.pan_display.Size = new System.Drawing.Size(1126, 558);
             this.pan_display.TabIndex = 7;
             // 
+            // chkQuestionReview
+            // 
+            this.chkQuestionReview.AutoSize = true;
+            this.chkQuestionReview.Location = new System.Drawing.Point(3, 3);
+            this.chkQuestionReview.Name = "chkQuestionReview";
+            this.chkQuestionReview.Size = new System.Drawing.Size(62, 17);
+            this.chkQuestionReview.TabIndex = 13;
+            this.chkQuestionReview.Text = "Review";
+            this.chkQuestionReview.UseVisualStyleBackColor = true;
+            this.chkQuestionReview.CheckedChanged += new System.EventHandler(this.chkQuestionReview_CheckedChanged);
+            // 
             // pct_image
             // 
             this.pct_image.Anchor = System.Windows.Forms.AnchorStyles.Top;
@@ -179,6 +194,23 @@
             this.pct_image.TabIndex = 12;
             this.pct_image.TabStop = false;
             this.pct_image.Visible = false;
+            // 
+            // lbl_explanation
+            // 
+            this.lbl_explanation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lbl_explanation.BackColor = System.Drawing.SystemColors.Control;
+            this.lbl_explanation.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.lbl_explanation.Cursor = System.Windows.Forms.Cursors.Default;
+            this.lbl_explanation.Location = new System.Drawing.Point(28, 435);
+            this.lbl_explanation.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lbl_explanation.Multiline = true;
+            this.lbl_explanation.Name = "lbl_explanation";
+            this.lbl_explanation.ReadOnly = true;
+            this.lbl_explanation.Size = new System.Drawing.Size(1071, 109);
+            this.lbl_explanation.TabIndex = 9;
+            this.lbl_explanation.Text = "lbl_explanation";
+            this.lbl_explanation.Visible = false;
             // 
             // txt_question
             // 
@@ -289,23 +321,6 @@
             this.btn_show_answer.Visible = false;
             this.btn_show_answer.Click += new System.EventHandler(this.ShowAnswer);
             // 
-            // lbl_explanation
-            // 
-            this.lbl_explanation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.lbl_explanation.BackColor = System.Drawing.SystemColors.Control;
-            this.lbl_explanation.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.lbl_explanation.Cursor = System.Windows.Forms.Cursors.Default;
-            this.lbl_explanation.Location = new System.Drawing.Point(28, 435);
-            this.lbl_explanation.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lbl_explanation.Multiline = true;
-            this.lbl_explanation.Name = "lbl_explanation";
-            this.lbl_explanation.ReadOnly = true;
-            this.lbl_explanation.Size = new System.Drawing.Size(1071, 109);
-            this.lbl_explanation.TabIndex = 9;
-            this.lbl_explanation.Text = "lbl_explanation";
-            this.lbl_explanation.Visible = false;
-            // 
             // btnHideAnswers
             // 
             this.btnHideAnswers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -342,6 +357,14 @@
             this.lblExamProgress.Text = " Exam Progress:";
             this.lblExamProgress.Visible = false;
             // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.chkQuestionReview);
+            this.panel1.Location = new System.Drawing.Point(1056, 3);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(65, 23);
+            this.panel1.TabIndex = 14;
+            // 
             // AssessmentUi
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -368,6 +391,8 @@
             this.pan_display.ResumeLayout(false);
             this.pan_display.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pct_image)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -398,5 +423,7 @@
         private System.Windows.Forms.Label dspExamProgress;
         private System.Windows.Forms.Label lblExamProgress;
         private System.Windows.Forms.TextBox lbl_explanation;
+        private System.Windows.Forms.CheckBox chkQuestionReview;
+        private System.Windows.Forms.Panel panel1;
     }
 }

--- a/src/apps/Simulator/GUI/AssessmentUi.cs
+++ b/src/apps/Simulator/GUI/AssessmentUi.cs
@@ -5,28 +5,35 @@ using System.Linq;
 using System.Windows.Forms;
 using Shared;
 using Shared.Models;
+using Shared.Util;
 
 namespace Simulator.GUI
 {
     public partial class AssessmentUi : Form
     {
-#region Global Variables
+        #region Global Variables
 
         private Exam _exam;
         private Settings _settings;
+        private readonly string _filePath;
         private int _timeLeft;
         private int _currentQuestionIndex;
+        private Guid _currentQuestionId;
         private object[] _userAnswers;
 
-#endregion
+        #endregion
 
-        public AssessmentUi(Exam exam, Settings settings)
+        public AssessmentUi(Exam exam, Settings settings, string filePath)
         {
             InitializeComponent();
             _exam = exam;
             _settings = settings;
+            _filePath = filePath;
             _timeLeft = settings.TimeLimit * 60;
             _userAnswers = new object[_exam.NumberOfQuestions];
+
+            chkQuestionReview.Visible = false;
+            chkQuestionReview.Checked = false;
         }
 
         private void TimerTick(object sender, EventArgs e)
@@ -80,6 +87,9 @@ namespace Simulator.GUI
             txt_question.Visible = true;
             lblExamProgress.Visible = true;
             dspExamProgress.Visible = true;
+
+            chkQuestionReview.Visible = true;
+            chkQuestionReview.Checked = false;
         }
 
         private void PauseExam(object sender, EventArgs e)
@@ -178,12 +188,12 @@ namespace Simulator.GUI
                 {
                     if (_userAnswers[i].GetType().IsArray)
                     {
-                        if (((char[]) _userAnswers[i]).SequenceEqual(_settings.Questions[i].Answers))
+                        if (((char[])_userAnswers[i]).SequenceEqual(_settings.Questions[i].Answers))
                         {
                             numOfCorrectAnswers++;
                         }
                     }
-                    else if ((char) _userAnswers[i] == _settings.Questions[i].Answer)
+                    else if ((char)_userAnswers[i] == _settings.Questions[i].Answer)
                     {
                         numOfCorrectAnswers++;
                     }
@@ -202,12 +212,12 @@ namespace Simulator.GUI
                             numOfQuestions++;
                             if (_userAnswers[i].GetType().IsArray)
                             {
-                                if (((char[]) _userAnswers[i]).SequenceEqual(_settings.Questions[i].Answers))
+                                if (((char[])_userAnswers[i]).SequenceEqual(_settings.Questions[i].Answers))
                                 {
                                     numOfCorrect++;
                                 }
                             }
-                            else if ((char) _userAnswers[i] == _settings.Questions[i].Answer)
+                            else if ((char)_userAnswers[i] == _settings.Questions[i].Answer)
                             {
                                 numOfCorrect++;
                             }
@@ -228,6 +238,8 @@ namespace Simulator.GUI
         private void PrintQuestionToScreen()
         {
             var question = _settings.Questions[_currentQuestionIndex];
+            _currentQuestionId = question.Id;
+            chkQuestionReview.Checked = question.Review;
             lbl_question_number.Text = question.No.ToString();
             lbl_section_title.Text = _settings.Sections.First(s => s.Questions.Contains(question)).Title;
             lbl_explanation.Text = question.Explanation;
@@ -257,7 +269,7 @@ namespace Simulator.GUI
                         Location = new Point(51, 300 + (i * 22))
                     };
                     if (_userAnswers[_currentQuestionIndex] != null &&
-                        ((char[]) _userAnswers[_currentQuestionIndex]).Contains(options[i].Alphabet))
+                        ((char[])_userAnswers[_currentQuestionIndex]).Contains(options[i].Alphabet))
                         chk.Checked = true;
                     pan_display.Controls.Add(chk);
                 }
@@ -271,7 +283,7 @@ namespace Simulator.GUI
                         Location = new Point(51, 300 + (i * 22))
                     };
                     if (_userAnswers[_currentQuestionIndex] != null &&
-                        (char) _userAnswers[_currentQuestionIndex] == options[i].Alphabet)
+                        (char)_userAnswers[_currentQuestionIndex] == options[i].Alphabet)
                         rdb.Checked = true;
                     pan_display.Controls.Add(rdb);
                 }
@@ -340,7 +352,7 @@ namespace Simulator.GUI
                 foreach (var answer in answers)
                 {
                     var index = pan_display.Controls.IndexOf(answer);
-                    ((CheckBox) pan_display.Controls[index]).ForeColor = Color.Green;
+                    ((CheckBox)pan_display.Controls[index]).ForeColor = Color.Green;
                 }
 
                 var selectedOptions = checkBoxes.Where(s => s.Checked);
@@ -350,7 +362,7 @@ namespace Simulator.GUI
                         .Contains(Convert.ToChar(selectedOption.Name.Replace("chk", ""))))
                     {
                         var index = pan_display.Controls.IndexOf(selectedOption);
-                        ((CheckBox) pan_display.Controls[index]).ForeColor = Color.Red;
+                        ((CheckBox)pan_display.Controls[index]).ForeColor = Color.Red;
                     }
                 }
             }
@@ -361,14 +373,14 @@ namespace Simulator.GUI
                 if (answer != null)
                 {
                     var index = pan_display.Controls.IndexOf(answer);
-                    ((RadioButton) pan_display.Controls[index]).ForeColor = Color.Green;
+                    ((RadioButton)pan_display.Controls[index]).ForeColor = Color.Green;
                 }
 
                 var currentSelectedOption = pan_display.Controls.OfType<RadioButton>().FirstOrDefault(s => s.Checked);
                 if (currentSelectedOption != null && currentSelectedOption.Text != answer.Text)
                 {
                     var index = pan_display.Controls.IndexOf(currentSelectedOption);
-                    ((RadioButton) pan_display.Controls[index]).ForeColor = Color.Red;
+                    ((RadioButton)pan_display.Controls[index]).ForeColor = Color.Red;
                 }
             }
         }
@@ -396,6 +408,16 @@ namespace Simulator.GUI
             lbl_explanation.Visible = false;
             btn_show_answer.Visible = true;
             btnHideAnswers.Visible = false;
+        }
+
+        private void chkQuestionReview_CheckedChanged(object sender, EventArgs e)
+        {
+            Question question = _exam.FindQuestionById(_currentQuestionId);
+
+            if (question != null)
+                question.Review = chkQuestionReview.Checked;
+
+            Writer.ToOef(_exam, _filePath);
         }
     }
 

--- a/src/apps/Simulator/GUI/AssessmentUi.cs
+++ b/src/apps/Simulator/GUI/AssessmentUi.cs
@@ -254,7 +254,7 @@ namespace Simulator.GUI
                         AutoSize = true,
                         Text = $"{options[i].Alphabet}. - {options[i].Text}",
                         Name = "chk" + options[i].Alphabet,
-                        Location = new Point(51, 464 + (i * 22))
+                        Location = new Point(51, 300 + (i * 22))
                     };
                     if (_userAnswers[_currentQuestionIndex] != null &&
                         ((char[]) _userAnswers[_currentQuestionIndex]).Contains(options[i].Alphabet))
@@ -268,7 +268,7 @@ namespace Simulator.GUI
                         AutoSize = true,
                         Text = options[i].Alphabet + ". - " + options[i].Text,
                         Name = "rdb" + options[i].Alphabet,
-                        Location = new Point(51, 464 + (i * 22))
+                        Location = new Point(51, 300 + (i * 22))
                     };
                     if (_userAnswers[_currentQuestionIndex] != null &&
                         (char) _userAnswers[_currentQuestionIndex] == options[i].Alphabet)

--- a/src/apps/Simulator/GUI/ExamSettingsUi.cs
+++ b/src/apps/Simulator/GUI/ExamSettingsUi.cs
@@ -9,13 +9,15 @@ namespace Simulator.GUI
     public partial class ExamSettingsUi : Form
     {
         private readonly Exam _exam;
+        private readonly string _filePath;
         private Settings _settings;
 
-        public ExamSettingsUi(Exam exam)
+        public ExamSettingsUi(Exam exam, string filePath)
         {
             InitializeComponent();
 
             _exam = exam;
+            _filePath = filePath;
 
             clb_section_options.Items.AddRange(_exam.Sections.ToArray());
 
@@ -111,7 +113,7 @@ namespace Simulator.GUI
                 return;
             }
 
-            var ui = new AssessmentUi(_exam, _settings);
+            var ui = new AssessmentUi(_exam, _settings, _filePath);
             Hide();
             ui.ShowDialog();
             Close();

--- a/src/apps/Simulator/Properties/AssemblyInfo.cs
+++ b/src/apps/Simulator/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0.0")]
-[assembly: AssemblyFileVersion("3.2.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/src/apps/Simulator/Util/DialogManager.cs
+++ b/src/apps/Simulator/Util/DialogManager.cs
@@ -1,8 +1,10 @@
 using System;
+using System.CodeDom;
 using System.IO;
 using System.Windows.Forms;
 using Logging;
 using Shared;
+using Shared.CompatibilityProvider;
 using Shared.Util;
 using Simulator.Enums;
 using Simulator.GUI;
@@ -13,13 +15,18 @@ namespace Simulator.Util
     {
         public static void DisplayDialog(DialogType dialogType, DataGridView dataGridView)
         {
+            CompatibilityProvider compatibilityProvider = new CompatibilityProvider();
             try
             {
                 var filePath = dataGridView.SelectedRows[0].Cells[1].Value.ToString();
                 var exam = Reader.FromOefFile(filePath);
+
+                compatibilityProvider.Patch(exam, filePath);
+
+
                 if (dialogType == DialogType.ExamSettings)
                 {
-                    InitilaizeExamSettings(exam);
+                    InitilaizeExamSettings(exam, filePath);
                 }
                 if (dialogType == DialogType.ExamProperties)
                 {
@@ -33,7 +40,7 @@ namespace Simulator.Util
                 MessageBox.Show("Sorry, the selected exam does not exist. It may have been moved or deleted.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 RowManager.RemoveRow(dataGridView);
             }
-            catch(NullReferenceException ex)
+            catch (NullReferenceException ex)
             {
                 Logger.LogException(ex);
 
@@ -48,9 +55,9 @@ namespace Simulator.Util
             properties.ShowDialog();
         }
 
-        private static void InitilaizeExamSettings(Exam exam)
+        private static void InitilaizeExamSettings(Exam exam, string filePath)
         {
-            var settings = new ExamSettingsUi(exam);
+            var settings = new ExamSettingsUi(exam, filePath);
             settings.ShowDialog();
         }
     }

--- a/src/lib/Shared/CompatibilityProvider/CompatibilityProvider.cs
+++ b/src/lib/Shared/CompatibilityProvider/CompatibilityProvider.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Shared.Util;
+
+namespace Shared.CompatibilityProvider
+{
+    public class CompatibilityProvider
+    {
+        private readonly List<ICompatibilityPatcher> _patchers;
+        private readonly int _fileVersion;
+
+        public CompatibilityProvider()
+        {
+            _patchers = new List<ICompatibilityPatcher> { new QuestionIdPatcher() };
+            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
+            _fileVersion = int.Parse(fvi.FileVersion[0].ToString());
+        }
+
+        public void Patch(Exam exam, string filePath)
+        {
+            if (exam.Properties.Version >= _patchers.Max(p => p.VersionThreshold))
+                return;
+
+            bool patchingWasRequired = false;
+
+            foreach (var compatibilityPatcher in _patchers.Where(p => p.VersionThreshold > exam.Properties.Version))
+            {
+                bool somethingPatched = compatibilityPatcher.Patch(exam);
+
+                if (!patchingWasRequired && somethingPatched)
+                    patchingWasRequired = true;
+            }
+
+            if (patchingWasRequired)
+                SaveExam(exam, filePath);
+        }
+
+        private void SaveExam(Exam exam, string filePath)
+        {
+            exam.Properties.Version = _fileVersion;
+            Writer.ToOef(exam, filePath);
+        }
+    }
+}

--- a/src/lib/Shared/CompatibilityProvider/ICompatibilityPatcher.cs
+++ b/src/lib/Shared/CompatibilityProvider/ICompatibilityPatcher.cs
@@ -1,0 +1,20 @@
+﻿namespace Shared.CompatibilityProvider
+{
+    public interface ICompatibilityPatcher
+    {
+        /// <summary>
+        /// Patches the exam if required
+        /// </summary>
+        /// <param name="exam">The exam to patch</param>
+        /// <returns>true if any patching took place</returns>
+        bool Patch(Exam exam);
+
+        /// <summary>
+        /// This is the version of the application that this patcher is no longer required to be execute.
+        /// For example;  if this was set to 4 for a specific patcher then it is assumed any exam below version 4
+        /// would require this patcher to be run on it.  Exams with version 4 or higher should not need this patcher
+        /// as the functionality should have been native during creation.
+        /// </summary>
+        int VersionThreshold { get; }
+    }
+}

--- a/src/lib/Shared/CompatibilityProvider/Patches/QuestionIdPatcher.cs
+++ b/src/lib/Shared/CompatibilityProvider/Patches/QuestionIdPatcher.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Shared.Extensions;
+
+namespace Shared.CompatibilityProvider
+{
+    /// <summary>
+    /// Patches exam questions to have a unique id
+    /// </summary>
+    public class QuestionIdPatcher : ICompatibilityPatcher
+    {
+        public int VersionThreshold => 4;
+
+        public bool Patch(Exam exam)
+        {
+            bool patched = false;
+
+            foreach (Section examSection in exam.Sections)
+            {
+                foreach (Question question in examSection.Questions)
+                {
+                    if (question.Id.IsDefault())
+                    {
+                        question.Id = Guid.NewGuid();
+
+                        if (!patched)
+                            patched = true;
+                    }
+                }
+            }
+
+            return patched;
+        }
+    }
+}

--- a/src/lib/Shared/Exam.cs
+++ b/src/lib/Shared/Exam.cs
@@ -35,7 +35,7 @@ namespace Shared
             var section = Sections.FirstOrDefault(s => s.Title == sectionName);
             if (section == null)
             {
-                section = new Section {Title = sectionName};
+                section = new Section { Title = sectionName };
                 Sections.Add(section);
             }
         }
@@ -69,6 +69,19 @@ namespace Shared
         {
             var section = Sections.FirstOrDefault(s => s.Title == sectionName);
             section?.Questions.Remove(question);
+        }
+
+        public Question FindQuestionById(Guid id)
+        {
+            foreach (Section section in Sections)
+            {
+                Question question = section.Questions.FirstOrDefault(q => q.Id.Equals(id));
+
+                if (question != null)
+                    return question;
+            }
+
+            return null;
         }
     }
 
@@ -109,6 +122,8 @@ namespace Shared
     [Serializable]
     public class Question
     {
+        public Guid Id { get; set; }
+
         public int No { get; set; }
 
         public string Text { get; set; }
@@ -124,6 +139,8 @@ namespace Shared
         public List<Option> Options { get; set; }
 
         public string Explanation { get; set; }
+
+        public bool Review { get; set; }
 
         public Question()
         {

--- a/src/lib/Shared/Extensions/DefaultExtensions.cs
+++ b/src/lib/Shared/Extensions/DefaultExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Shared.Extensions
+{
+    public static class DefaultExtensions
+    {
+        public static bool IsDefault(this Guid instance)
+        {
+            return instance == default(Guid);
+        }
+        public static bool IsNotDefault(this Guid instance)
+        {
+            return !IsDefault(instance);
+        }
+    }
+}

--- a/src/lib/Shared/Properties/AssemblyInfo.cs
+++ b/src/lib/Shared/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0.0")]
-[assembly: AssemblyFileVersion("3.2.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/src/lib/Shared/Shared.csproj
+++ b/src/lib/Shared/Shared.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CompatibilityProvider\CompatibilityProvider.cs" />
+    <Compile Include="CompatibilityProvider\ICompatibilityPatcher.cs" />
+    <Compile Include="CompatibilityProvider\Patches\QuestionIdPatcher.cs" />
     <Compile Include="Controls\OptionControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -45,6 +48,7 @@
     <Compile Include="Controls\TreeNodes.cs" />
     <Compile Include="Enums\ActionType.cs" />
     <Compile Include="Exam.cs" />
+    <Compile Include="Extensions\DefaultExtensions.cs" />
     <Compile Include="Interfaces\IUndoRedo.cs" />
     <Compile Include="Models\ChangeRepresentationObject.cs" />
     <Compile Include="Models\Settings.cs" />

--- a/tests/Shared.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Shared.Tests/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0.0")]
-[assembly: AssemblyFileVersion("3.2.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]


### PR DESCRIPTION
This is the first of two parts.  This pull request allows users to mark questions in tests with a review flag.

To achieve this it was necessary to;

- Ensure each question is uniquely identifiable (added a Guid property on each question)

- Support patching of older exam versions (added a patching solution)

- Increased the version number to 4 (due to the current version only being major in exam files)

**Methodology of implementation**
User loads an existing exam and the patching system will patch it so each question get's a unique Id, alternatively a new exam is created and so each question will have a new Id as this is now native functionality from v4.

During the exam a user can use the new review checkbox (top right) to mark a question for review;  this is persisted in the exam file itself for now (pro's and con's of it being stored here).

This is then shown as checked or unchecked the next time the exam is taken.  I wanted to get this first PR in and tested on older exam file formats to check the patching algorithm.  

Next part will include;

1.Take an exam using only questions that are marked for review. 
