### PR TITLE
closes #96 | fixes issues with creating exams in locales that use commas as decimal separators

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>4.0.1</Version>
-    <AssemblyVersion>4.0.1</AssemblyVersion>
+    <Version>4.0.2</Version>
+    <AssemblyVersion>4.0.2</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/apps/Creator/GUI/HomeUi.cs
+++ b/src/apps/Creator/GUI/HomeUi.cs
@@ -754,7 +754,7 @@ public partial class HomeUi : Form
             TimeLimit = (int)num_time_limit.Value,
             Title = txt_title.Text,
             HideAnswers = chk_hide_answers.Checked,
-            Version = (int)float.Parse(lbl_version.Text)
+            Version = 4 // replaces parsing the version label
         };
         if (trv_view_exam.Nodes.Count > 0)
         {


### PR DESCRIPTION
- closes #96 and #106